### PR TITLE
Added color change functionality to validation label text

### DIFF
--- a/lib/components/validator_item.dart
+++ b/lib/components/validator_item.dart
@@ -6,9 +6,10 @@ class ValidatorItemWidget extends StatelessWidget {
   final int conditionValue;
   final Color color;
   final bool value;
+  final Color? textColor;
 
   const ValidatorItemWidget(
-      this.text, this.conditionValue, this.color, this.value,
+      this.text, this.conditionValue, this.color, this.value, this.textColor,
       {Key? key})
       : super(key: key);
   @override
@@ -32,7 +33,15 @@ class ValidatorItemWidget extends StatelessWidget {
             padding: const EdgeInsets.only(
               left: 10,
             ),
-            child: Text('$text (${conditionValue.toString()})'),
+            child: textColor == null ?
+            Text(
+              '$text (${conditionValue.toString()})',
+            ) : Text(
+              '$text (${conditionValue.toString()})',
+              style: TextStyle(
+                color: textColor
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/password_field_validator.dart
+++ b/lib/password_field_validator.dart
@@ -15,6 +15,7 @@ class PasswordFieldValidator extends StatefulWidget {
   final Color defaultColor;
   final Color successColor;
   final Color failureColor;
+  final Color? textColor;
   final TextEditingController controller;
 
   final String? minLengthMessage;
@@ -34,6 +35,7 @@ class PasswordFieldValidator extends StatefulWidget {
       required this.successColor,
       required this.failureColor,
       required this.controller,
+      this.textColor,
       this.minLengthMessage,
       this.uppercaseCharMessage,
       this.lowercaseMessage,
@@ -157,6 +159,7 @@ class _PasswordFieldValidatorState extends State<PasswordFieldValidator> {
                   ? widget.successColor
                   : widget.failureColor,
           entry.value,
+          widget.textColor
         );
       }).toList(),
     );


### PR DESCRIPTION
Created additional variable within PasswordFieldValidator which allows users to specify text color of labels when setting up their password validator. This is an optional variable as well so the old behavior will still work if textColor is not specified by user.